### PR TITLE
Fix `IndexError`

### DIFF
--- a/src/opensuse_distro_aliases/__init__.py
+++ b/src/opensuse_distro_aliases/__init__.py
@@ -66,7 +66,7 @@ def get_distro_aliases(include_eol: bool = False) -> Dict[str, List[Distro]]:
         if distro_name == "LeapMicro":
             distro_name = "Leap-Micro"
 
-        if distro_name == "Tumbleweed":
+        if distro_name == "Tumbleweed" and distro_list:
             d = distro_list[0]
             aliases.append(
                 Distro(


### PR DESCRIPTION
At this moment, `get_distro_aliases()` tracebacks with:

```
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    get_distro_aliases()
    ~~~~~~~~~~~~~~~~~~^^
  File "src/opensuse_distro_aliases/__init__.py", line 70, in get_distro_aliases
    d = distro_list[0]
        ~~~~~~~~~~~^^^
IndexError: list index out of range
```

because the value for "Tumbleweed" in `distributions.json` is an empty list.

Handle such case.

---

Do the cached aliases need an update too?